### PR TITLE
ArsenalOfDemocracy 1.12

### DIFF
--- a/EuropaEnginePatcher/EuropaEnginePatcher.cs
+++ b/EuropaEnginePatcher/EuropaEnginePatcher.cs
@@ -11,7 +11,7 @@ namespace EuropaEnginePatcher
         /// <summary>
         ///     バージョン名
         /// </summary>
-        internal const string VersionName = "0.55";
+        internal const string VersionName = "0.56";
 
         /// <summary>
         ///     エントリーポイント

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -256,7 +256,7 @@ namespace EuropaEnginePatcher
                     break;
 
                 case GameType.ArsenalOfDemocracy:
-                    _patchType = PatchType.ArsenalOfDemocracy;
+                    _patchType = PatchType.ArsenalOfDemocracyVersionUnknown;
                     AppendLog("PatchType: Arsenal of Democracy\n\n");
                     break;
 
@@ -281,7 +281,7 @@ namespace EuropaEnginePatcher
             switch (_patchType)
             {
                 case PatchType.HeartsOfIron2:
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracyVersionUnknown:
                 case PatchType.DarkestHourVersionUnkonwn:
                     break;
 
@@ -332,7 +332,7 @@ namespace EuropaEnginePatcher
                     }
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracyVersionUnknown:
                     // Arsenal of Democracy X.XX
                     pattern = new byte[]
                     {
@@ -418,7 +418,7 @@ namespace EuropaEnginePatcher
                     }
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracyVersionUnknown:
                     if (_gameVersion <= 104)
                     {
                         _patchType = PatchType.ArsenalOfDemocracy104;
@@ -429,15 +429,22 @@ namespace EuropaEnginePatcher
                         _patchType = PatchType.ArsenalOfDemocracy107;
                         AppendLog("PatchType: Arsenal of Democracy 1.07\n\n");
                     }
-                    else if (_gameVersion <= 109)
+                    else if (_gameVersion == 109)
                     {
                         _patchType = PatchType.ArsenalOfDemocracy109;
                         AppendLog("PatchType: Arsenal of Democracy 1.09\n\n");
                     }
-                    else
+                    else if (_gameVersion == 110)
                     {
-                        _patchType = PatchType.ArsenalOfDemocracy;
+                        _patchType = PatchType.ArsenalOfDemocracy110;
                         AppendLog("PatchType: Arsenal of Democracy\n\n");
+                    } else if (_gameVersion == 112)
+                    {
+                        _patchType = PatchType.ArsenalOfDemocracy112;
+                        AppendLog("PatchType: Arsenal of Democracy\n\n");
+                    } else
+                    {
+                        AppendLog("Not Support version\n\n");
                     }
                     break;
 
@@ -459,7 +466,7 @@ namespace EuropaEnginePatcher
                     }
                     else
                     {
-                        AppendLog("Version is unknown\n\n");
+                        AppendLog("Not Support version\n\n");
                     }
                     break;
             }
@@ -895,10 +902,11 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:                
@@ -956,9 +964,9 @@ namespace EuropaEnginePatcher
                     case PatchType.HeartsOfIron2:
                     case PatchType.HeartsOfIron212:
                     case PatchType.IronCrossHoI2:
-                    case PatchType.ArsenalOfDemocracy104:
-                    case PatchType.ArsenalOfDemocracy107:
                     case PatchType.ArsenalOfDemocracy109:
+                    case PatchType.ArsenalOfDemocracy107:
+                    case PatchType.ArsenalOfDemocracy104:
                     case PatchType.DarkestHour105:
                     case PatchType.DarkestHour104:
                     case PatchType.DarkestHour102:                    
@@ -980,7 +988,8 @@ namespace EuropaEnginePatcher
                         }
                         break;
 
-                    case PatchType.ArsenalOfDemocracy:
+                    case PatchType.ArsenalOfDemocracy112:
+                    case PatchType.ArsenalOfDemocracy110:
                         if (!ScanGetDivisionName())
                         {
                             return false;
@@ -1070,10 +1079,11 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:                
@@ -1129,7 +1139,8 @@ namespace EuropaEnginePatcher
             byte[] pattern;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0x8B, 0x45, 0x78, 0x8B, 0x48, 0x0C, 0x89, 0x4D
@@ -1190,8 +1201,8 @@ namespace EuropaEnginePatcher
                     };
                     break;
 
-                case PatchType.ArsenalOfDemocracy107:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:                
                     pattern = new byte[]
                     {
                         0x8B, 0x55, 0x18, 0x8B, 0x02, 0x8B, 0x4D, 0x18,
@@ -1200,7 +1211,8 @@ namespace EuropaEnginePatcher
                     };
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0x8B, 0x55, 0x78, 0x8B, 0x02, 0x8B, 0x4D, 0x78,
@@ -1255,7 +1267,8 @@ namespace EuropaEnginePatcher
                     };
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0xC7, 0x45, 0xF4, 0x00, 0x00, 0x00, 0x00, 0x8B,
@@ -1295,7 +1308,8 @@ namespace EuropaEnginePatcher
             byte[] pattern;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0x8B, 0x45, 0xF4, 0x8B, 0xE5, 0x5D, 0xC2, 0x04,
@@ -1335,15 +1349,16 @@ namespace EuropaEnginePatcher
             byte[] pattern;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0x75, 0x1A, 0x8B, 0xCB, 0x8D, 0x51, 0x01
                     };
                     break;
 
-                case PatchType.ArsenalOfDemocracy107:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
                     pattern = new byte[]
                     {
                         0x75, 0x1A, 0x8B, 0xC7, 0x8D, 0x50, 0x01
@@ -1381,9 +1396,10 @@ namespace EuropaEnginePatcher
             List<uint> l;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
                     pattern = new byte[]
                     {
                         0x3D, 0xA7, 0x00, 0x00, 0x00, 0x0F, 0x8F
@@ -1815,7 +1831,8 @@ namespace EuropaEnginePatcher
                     _posCalcLineBreakStart5 = l[0];
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0x88, 0x5C, 0x14, 0x0C, 0x42
@@ -2313,7 +2330,8 @@ namespace EuropaEnginePatcher
                     _posCalcLineBreakEnd6 = l[0] + (uint) pattern.Length;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0x8D, 0x84, 0x24, 0x0C, 0x02, 0x00, 0x00, 0x66,
@@ -2417,9 +2435,9 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:                
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:				
@@ -2448,7 +2466,8 @@ namespace EuropaEnginePatcher
                     _posGetDivisionName2 = l[0];
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0x2E, 0x20, 0x00, 0x00
@@ -2495,9 +2514,10 @@ namespace EuropaEnginePatcher
             List<uint> l;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
                     l = BinaryScan(_data, pattern, _posRdataSection, _sizeRdataSection);
                     break;
 
@@ -2584,9 +2604,9 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:				
@@ -2615,7 +2635,8 @@ namespace EuropaEnginePatcher
                     _posGetArmyName2 = l[0];
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0xC7, 0x45, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, 0x8B,
@@ -2662,9 +2683,10 @@ namespace EuropaEnginePatcher
             List<uint> l;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
                     l = BinaryScan(_data, pattern, _posRdataSection, _sizeRdataSection);
                     break;
 
@@ -3203,7 +3225,8 @@ namespace EuropaEnginePatcher
             byte[] pattern = null;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
                         0xC6, 0x85, 0x50, 0xFF, 0xFF, 0xFF, 0x00, 0x6A,
@@ -3265,7 +3288,8 @@ namespace EuropaEnginePatcher
             }
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     _posTermModelNameStart1 = l[0];
                     _posTermModelNameStart2 = l[1];
@@ -3328,10 +3352,11 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:				
@@ -3343,7 +3368,8 @@ namespace EuropaEnginePatcher
             switch (_patchType)
             {
                 case PatchType.ForTheGlory:
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     PatchIsDebuggerPresent();
                     break;
@@ -3377,9 +3403,9 @@ namespace EuropaEnginePatcher
                     case PatchType.HeartsOfIron2:
                     case PatchType.HeartsOfIron212:
                     case PatchType.IronCrossHoI2:
-                    case PatchType.ArsenalOfDemocracy104:
-                    case PatchType.ArsenalOfDemocracy107:
                     case PatchType.ArsenalOfDemocracy109:
+                    case PatchType.ArsenalOfDemocracy107:
+                    case PatchType.ArsenalOfDemocracy104:                    
                     case PatchType.DarkestHour105:
                     case PatchType.DarkestHour104:
                     case PatchType.DarkestHour102:					
@@ -3389,7 +3415,8 @@ namespace EuropaEnginePatcher
                         EmbedArmyNameFormat();
                         break;
 
-                    case PatchType.ArsenalOfDemocracy:
+                    case PatchType.ArsenalOfDemocracy112:
+                    case PatchType.ArsenalOfDemocracy110:
                         PatchGetDivisionName();
                         PatchGetArmyName();
                         break;
@@ -3467,10 +3494,11 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:				
@@ -3524,7 +3552,8 @@ namespace EuropaEnginePatcher
             switch (_patchType)
             {
                 case PatchType.ForTheGlory:
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     PatchLong(_data, offset, _addrIsDebuggerPresent,
                         $"%04 ${_addrIsDebuggerPresent:X8} IsDebuggerPresent");
@@ -3599,15 +3628,16 @@ namespace EuropaEnginePatcher
                     case PatchType.HeartsOfIron2:
                     case PatchType.HeartsOfIron212:
                     case PatchType.IronCrossHoI2:
-                    case PatchType.ArsenalOfDemocracy104:
-                    case PatchType.ArsenalOfDemocracy107:
                     case PatchType.ArsenalOfDemocracy109:
+                    case PatchType.ArsenalOfDemocracy107:
+                    case PatchType.ArsenalOfDemocracy104:
                     case PatchType.DarkestHour105:
                     case PatchType.DarkestHour104:
                     case PatchType.DarkestHour102:					
                         PatchByte(_data, offset, 0x94);
                         break;
-                    case PatchType.ArsenalOfDemocracy:
+                    case PatchType.ArsenalOfDemocracy112:
+                    case PatchType.ArsenalOfDemocracy110:
                         PatchByte(_data, offset, 0x58);
                         break;
                     default:
@@ -3705,10 +3735,11 @@ namespace EuropaEnginePatcher
                     case PatchType.HeartsOfIron2:
                     case PatchType.HeartsOfIron212:
                     case PatchType.IronCrossHoI2:
-                    case PatchType.ArsenalOfDemocracy:
-                    case PatchType.ArsenalOfDemocracy104:
-                    case PatchType.ArsenalOfDemocracy107:
+                    case PatchType.ArsenalOfDemocracy112:
+                    case PatchType.ArsenalOfDemocracy110:
                     case PatchType.ArsenalOfDemocracy109:
+                    case PatchType.ArsenalOfDemocracy107:
+                    case PatchType.ArsenalOfDemocracy104:
                     case PatchType.DarkestHour105:
                     case PatchType.DarkestHour104:
                     case PatchType.DarkestHour102:					
@@ -3796,7 +3827,7 @@ namespace EuropaEnginePatcher
                 offset++;
                 PatchByte(_data, offset, 0x75);
                 offset++;
-                PatchByte(_data, offset, (byte) (_patchType == PatchType.ArsenalOfDemocracy ? 0x7C : 0x1C));
+                PatchByte(_data, offset, (byte) ((_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112) ? 0x7C : 0x1C));
                 offset++;
                 PatchByte(_data, offset, 0x8B); // mov eax,[ecx+10h]
                 offset++;
@@ -3848,7 +3879,7 @@ namespace EuropaEnginePatcher
             offset++;
             PatchByte(_data, offset, 0x55);
             offset++;
-            PatchByte(_data, offset, (byte) (_patchType == PatchType.ArsenalOfDemocracy ? 0x78 : 0x18));
+            PatchByte(_data, offset, (byte) ((_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112) ? 0x78 : 0x18));
             offset++;
             PatchByte(_data, offset, 0xFF); // push [edx+2Ch]
             offset++;
@@ -3860,13 +3891,13 @@ namespace EuropaEnginePatcher
             offset++;
             PatchByte(_data, offset, 0x75);
             offset++;
-            PatchByte(_data, offset, (byte) (_patchType == PatchType.ArsenalOfDemocracy ? 0x68 : 0x08));
+            PatchByte(_data, offset, (byte) ((_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112) ? 0x68 : 0x08));
             offset++;
             PatchByte(_data, offset, 0x8D); // lea eax,[ebp+10h/70h]
             offset++;
             PatchByte(_data, offset, 0x45);
             offset++;
-            PatchByte(_data, offset, (byte) (_patchType == PatchType.ArsenalOfDemocracy ? 0x70 : 0x10));
+            PatchByte(_data, offset, (byte) ((_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112) ? 0x70 : 0x10));
             offset++;
             PatchByte(_data, offset, 0x50); // push eax
             offset++;
@@ -3874,7 +3905,7 @@ namespace EuropaEnginePatcher
             offset++;
             PatchByte(_data, offset, 0x45);
             offset++;
-            PatchByte(_data, offset, (byte) (_patchType == PatchType.ArsenalOfDemocracy ? 0x6C : 0x0C));
+            PatchByte(_data, offset, (byte) ((_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112) ? 0x6C : 0x0C));
             offset++;
             PatchByte(_data, offset, 0x50); // push eax
             offset++;
@@ -3882,7 +3913,7 @@ namespace EuropaEnginePatcher
             offset++;
             PatchByte(_data, offset, 0x75);
             offset++;
-            PatchByte(_data, offset, (byte) (_patchType == PatchType.ArsenalOfDemocracy ? 0x74 : 0x14));
+            PatchByte(_data, offset, (byte) ((_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112) ? 0x74 : 0x14));
             offset++;
             PatchByte(_data, offset, 0xFF); // call [varTextOutDC2Address]
             offset++;
@@ -3933,7 +3964,8 @@ namespace EuropaEnginePatcher
             switch (_patchType)
             {
                 case PatchType.ForTheGlory:
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     PatchLong(_data, offset, _addrIsDebuggerPresent,
                         $"%04 ${_addrIsDebuggerPresent:X8} IsDebuggerPresent");
@@ -3991,12 +4023,13 @@ namespace EuropaEnginePatcher
             offset++;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0xF8);
                     break;
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:                
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:				
@@ -4050,10 +4083,11 @@ namespace EuropaEnginePatcher
                     case PatchType.HeartsOfIron2:
                     case PatchType.HeartsOfIron212:
                     case PatchType.IronCrossHoI2:
-                    case PatchType.ArsenalOfDemocracy:
-                    case PatchType.ArsenalOfDemocracy104:
-                    case PatchType.ArsenalOfDemocracy107:
+                    case PatchType.ArsenalOfDemocracy112:
+                    case PatchType.ArsenalOfDemocracy110:
                     case PatchType.ArsenalOfDemocracy109:
+                    case PatchType.ArsenalOfDemocracy107:
+                    case PatchType.ArsenalOfDemocracy104:
                     case PatchType.DarkestHour105:
                     case PatchType.DarkestHour104:
                     case PatchType.DarkestHour102:					
@@ -4228,7 +4262,8 @@ namespace EuropaEnginePatcher
                     PatchByte(_data, offset, 0x17);
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     PatchByte(_data, offset, 0x16);
                     break;
@@ -4248,9 +4283,10 @@ namespace EuropaEnginePatcher
             AppendLog("  proc ChatBlockChar書き換え\n");
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
-                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
                     // 0x5C
                     PatchByte(_data, _posChatBlockChar1 + 0x5C + 0x59, 0x08);
                     PatchByte(_data, _posChatBlockChar2 + 0x5C - 0x2C, 0x01);
@@ -4328,7 +4364,8 @@ namespace EuropaEnginePatcher
             switch (_patchType)
             {
                 case PatchType.ForTheGlory:
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     PatchLong(_data, offset, _addrIsDebuggerPresent,
                         $"%04 ${_addrIsDebuggerPresent:X8} IsDebuggerPresent");
@@ -4471,7 +4508,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x8D); // lea esi,[esi-1]
                     offset++;
                     PatchByte(_data, offset, 0x76);
@@ -4821,7 +4859,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x01); // add esi,eax
                     offset++;
                     PatchByte(_data, offset, 0xC6);
@@ -5011,7 +5050,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x8D); // lea edi,[edi-01h]
                     offset++;
                     PatchByte(_data, offset, 0x7F);
@@ -5367,7 +5407,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x01); // add edi,eax
                     offset++;
                     PatchByte(_data, offset, 0xC7);
@@ -5548,7 +5589,8 @@ namespace EuropaEnginePatcher
                         offset++;
                         break;
 
-                    case PatchType.ArsenalOfDemocracy:
+                    case PatchType.ArsenalOfDemocracy112:
+                    case PatchType.ArsenalOfDemocracy110:
                         PatchByte(_data, offset, 0x8D); // lea esi,[esi-01h]
                         offset++;
                         PatchByte(_data, offset, 0x76);
@@ -5779,7 +5821,8 @@ namespace EuropaEnginePatcher
                         offset++;
                         break;
 
-                    case PatchType.ArsenalOfDemocracy:
+                    case PatchType.ArsenalOfDemocracy112:
+                    case PatchType.ArsenalOfDemocracy110:
                         PatchByte(_data, offset, 0x01); // add esi,eax
                         offset++;
                         PatchByte(_data, offset, 0xC6);
@@ -6085,7 +6128,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x8D); // lea esi,[esi-01h]
                     offset++;
                     PatchByte(_data, offset, 0x76);
@@ -6413,7 +6457,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x01); // add esi,eax
                     offset++;
                     PatchByte(_data, offset, 0xC6);
@@ -6615,7 +6660,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x8D); // lea esi,[esi-01h]
                     offset++;
                     PatchByte(_data, offset, 0x76);
@@ -6955,7 +7001,8 @@ namespace EuropaEnginePatcher
                     offset++;
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x01); // add esi,eax
                     offset++;
                     PatchByte(_data, offset, 0xC6);
@@ -7193,9 +7240,9 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:                
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:
@@ -7261,7 +7308,8 @@ namespace EuropaEnginePatcher
                         $"%XX ${GetRelativeAddress(GetTextAddress(offset + 4), offsetGetDivisionOrderName):X8} GetDivisionOrderName");
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     uint addrDivisionAbbrev = GetLong(_posGetDivisionName1);
                     PatchLong(_data, _posGetDivisionName1, addrDivisionAbbrev + 2,
                         $"%XX ${(addrDivisionAbbrev + 2):X8} addrDivisionAbbrev");
@@ -7315,9 +7363,9 @@ namespace EuropaEnginePatcher
                 case PatchType.HeartsOfIron2:
                 case PatchType.HeartsOfIron212:
                 case PatchType.IronCrossHoI2:
-                case PatchType.ArsenalOfDemocracy104:
-                case PatchType.ArsenalOfDemocracy107:
                 case PatchType.ArsenalOfDemocracy109:
+                case PatchType.ArsenalOfDemocracy107:
+                case PatchType.ArsenalOfDemocracy104:                
                 case PatchType.DarkestHour105:
                 case PatchType.DarkestHour104:
                 case PatchType.DarkestHour102:
@@ -7349,9 +7397,10 @@ namespace EuropaEnginePatcher
                             offset++;
                             PatchByte(_data, offset, 0xFE);
                             break;
-                        case PatchType.ArsenalOfDemocracy:
-                        case PatchType.ArsenalOfDemocracy107:
+                        case PatchType.ArsenalOfDemocracy112:
+                        case PatchType.ArsenalOfDemocracy110:
                         case PatchType.ArsenalOfDemocracy109:
+                        case PatchType.ArsenalOfDemocracy107:                        
                             PatchByte(_data, offset, 0xD0);
                             offset++;
                             PatchByte(_data, offset, 0xFD);
@@ -7402,9 +7451,10 @@ namespace EuropaEnginePatcher
                             offset++;
                             PatchByte(_data, offset, 0xFE);
                             break;
-                        case PatchType.ArsenalOfDemocracy:
-                        case PatchType.ArsenalOfDemocracy107:
+                        case PatchType.ArsenalOfDemocracy112:
+                        case PatchType.ArsenalOfDemocracy110:
                         case PatchType.ArsenalOfDemocracy109:
+                        case PatchType.ArsenalOfDemocracy107:
                             PatchByte(_data, offset, 0xA4);
                             offset++;
                             PatchByte(_data, offset, 0xFD);
@@ -7435,7 +7485,8 @@ namespace EuropaEnginePatcher
                         $"%XX ${GetRelativeAddress(GetTextAddress(offset + 4), offsetGetArmyOrderName):X8} GetArmyOrderName");
                     break;
 
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     uint addrBufOrdinal = GetLong(_posGetArmyName1 + 5);
                     uint addrPutNumber = GetLong(_posGetArmyName1 + 11);
                     offset = _posGetArmyName1;
@@ -7767,7 +7818,8 @@ namespace EuropaEnginePatcher
             offset++;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     PatchLong(_data, offset, _addrIsDebuggerPresent,
                         $"%04 ${_addrIsDebuggerPresent:X8} IsDebuggerPresent");
@@ -7836,7 +7888,8 @@ namespace EuropaEnginePatcher
             offset++;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x8D); // lea eax,[ebp-CCh]
                     offset++;
                     PatchByte(_data, offset, 0x85);
@@ -7915,7 +7968,8 @@ namespace EuropaEnginePatcher
             offset += 4;
             switch (_patchType)
             {
-                case PatchType.ArsenalOfDemocracy:
+                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0xC6); // mov byte ptr [ebp+eax-CCh],0
                     offset++;
                     PatchByte(_data, offset, 0x84);
@@ -8137,7 +8191,7 @@ namespace EuropaEnginePatcher
                     $"%XX ${GetTextAddress(posTermModelName):X8} TermModelName");
                 _posTermModelNameStart1 += 4;
 
-                if (_patchType == PatchType.ArsenalOfDemocracy)
+                if (_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112)
                 {
                     PatchByte(_data, _posTermModelNameStart1, 0x90); // nop
                     _posTermModelNameStart1++;
@@ -8152,7 +8206,7 @@ namespace EuropaEnginePatcher
                     $"%XX ${GetTextAddress(posTermModelName):X8} TermModelName");
                 _posTermModelNameStart2 += 4;
 
-                if (_patchType == PatchType.ArsenalOfDemocracy)
+                if (_patchType == PatchType.ArsenalOfDemocracy110 || _patchType == PatchType.ArsenalOfDemocracy112)
                 {
                     PatchByte(_data, _posTermModelNameStart2, 0x90); // nop
                     _posTermModelNameStart2++;
@@ -8453,14 +8507,17 @@ namespace EuropaEnginePatcher
         ForTheGlory, // For The Glory
         Victoria, // Victoria
         HeartsOfIron, // Hearts of Iron
-        HeartsOfIron2, // Hearts of Iron 2 1.3-
-        ArsenalOfDemocracy, // Arsenal of Democracy 1.10-
+        HeartsOfIron2, // Hearts of Iron 2 1.3-        
         DarkestHourVersionUnkonwn,
         DarkestHour104, // Darkest Hour 1.03-1.04
-        DarkestHour105, // Darkest Hour 1.05
+        DarkestHour105, // Darkest Hour 1.05    
+        ArsenalOfDemocracyVersionUnknown,
         ArsenalOfDemocracy104, // Arsenal of Democracy 1.02-1.04
         ArsenalOfDemocracy107, // Arsenal of Democracy 1.05-1.07
         ArsenalOfDemocracy109, // Arsenal of Democracy 1.08-1.09
+        ArsenalOfDemocracy110, // Arsenal of Democracy 1.10
+        ArsenalOfDemocracy111, // Arsenal of Democracy 1.11
+        ArsenalOfDemocracy112, // Arsenal of Democracy 1.12
         DarkestHour102, // Darkest Hour 1.00-1.02
         HeartsOfIron212, // Hearts of Iron 2 1.2
         IronCrossHoI2 // Iron Cross over Hearts of Iron 2

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -1876,31 +1876,16 @@ namespace EuropaEnginePatcher
                         return false;
                     }
                     _posCalcLineBreakStart3 = l[0];
-                    
-                    switch (_patchType) {
+
+                    // _posCalcLineBreakStart5
+                    switch (_patchType)
+                    {
                         case PatchType.ArsenalOfDemocracy110:
                             pattern = new byte[]
                             {
                                 0x88, 0x9C, 0x0D, 0xE8, 0xFD, 0xFF, 0xFF,
                                 0x41
                             };
-                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
-                            if (l.Count == 0)
-                            {
-                                return false;
-                            }
-                            _posCalcLineBreakStart5 = l[0];
-
-                            pattern = new byte[]
-                            {
-                                0x88, 0x9C, 0x0D, 0xEC, 0xFD, 0xFF, 0xFF, 0x41
-                            };
-                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
-                            if (l.Count == 0)
-                            {
-                                return false;
-                            }
-                            _posCalcLineBreakStart6 = l[0];
                             break;
                         case PatchType.ArsenalOfDemocracy112:
                             pattern = new byte[]
@@ -1908,25 +1893,39 @@ namespace EuropaEnginePatcher
                                 0x88, 0x9C, 0x0D, 0xE0, 0xFD, 0xFF, 0xFF, // mov     byte ptr [ebp+ecx+var_220], bl
                                 0x41 // inc ecx
                             };
-                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
-                            if (l.Count == 0)
+                            break;
+                    }
+                    l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                    if (l.Count == 0)
+                    {
+                        return false;
+                    }
+                    _posCalcLineBreakStart5 = l[0];
+
+
+                    // _posCalcLineBreakStart6
+                    switch (_patchType)
+                    {
+                        case PatchType.ArsenalOfDemocracy110:
+                            pattern = new byte[]
                             {
-                                return false;
-                            }
-                            _posCalcLineBreakStart5 = l[0];
+                                0x88, 0x9C, 0x0D, 0xEC, 0xFD, 0xFF, 0xFF, 0x41
+                            };
+                            break;
+                        case PatchType.ArsenalOfDemocracy112:
                             pattern = new byte[]
                             {
                                 0x88, 0x94, 0x0D, 0x34, 0xFB, 0xFF, 0xFF , // mov     byte ptr [ebp+ecx+var_4CC], dl
                                 0x41 // inc ecx
                             };
-                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
-                            if (l.Count == 0)
-                            {
-                                return false;
-                            }
-                            _posCalcLineBreakStart6 = l[0];
                             break;
                     }
+                    l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                    if (l.Count == 0)
+                    {
+                        return false;
+                    }
+                    _posCalcLineBreakStart6 = l[0];
                     break;
             }
 

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -1350,10 +1350,20 @@ namespace EuropaEnginePatcher
             switch (_patchType)
             {
                 case PatchType.ArsenalOfDemocracy112:
+                    pattern = new byte[]
+                    {
+                        0x75, 0x1A, // short loc_xxxxx
+                        0x8B, 0xCE, // mov ecx, esi
+                        0x8D, 0x51, 0x01 // lea edx, [ecx + 1]
+                    };
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
-                        0x75, 0x1A, 0x8B, 0xCB, 0x8D, 0x51, 0x01
+                        0x75, 0x1A, // short loc_xxxxx
+                        0x8B, 0xCB, // mov ecx, ebx
+                        0x8D, 0x51, 0x01 // lea edx, [ecx+1]
                     };
                     break;
 
@@ -1857,7 +1867,8 @@ namespace EuropaEnginePatcher
 
                     pattern = new byte[]
                     {
-                        0x88, 0x94, 0x0D, 0xE8, 0xFD, 0xFF, 0xFF, 0x41
+                        0x88, 0x94, 0x0D, 0xE8, 0xFD, 0xFF, 0xFF,  // mov     byte ptr [ebp+ecx+var_218], bl
+                        0x41 // inc ecx
                     };
                     l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
                     if (l.Count == 0)
@@ -1865,28 +1876,57 @@ namespace EuropaEnginePatcher
                         return false;
                     }
                     _posCalcLineBreakStart3 = l[0];
+                    
+                    switch (_patchType) {
+                        case PatchType.ArsenalOfDemocracy110:
+                            pattern = new byte[]
+                            {
+                                0x88, 0x9C, 0x0D, 0xE8, 0xFD, 0xFF, 0xFF,
+                                0x41
+                            };
+                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                            if (l.Count == 0)
+                            {
+                                return false;
+                            }
+                            _posCalcLineBreakStart5 = l[0];
 
-                    pattern = new byte[]
-                    {
-                        0x88, 0x9C, 0x0D, 0xE8, 0xFD, 0xFF, 0xFF, 0x41
-                    };
-                    l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
-                    if (l.Count == 0)
-                    {
-                        return false;
+                            pattern = new byte[]
+                            {
+                                0x88, 0x9C, 0x0D, 0xEC, 0xFD, 0xFF, 0xFF, 0x41
+                            };
+                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                            if (l.Count == 0)
+                            {
+                                return false;
+                            }
+                            _posCalcLineBreakStart6 = l[0];
+                            break;
+                        case PatchType.ArsenalOfDemocracy112:
+                            pattern = new byte[]
+                            {
+                                0x88, 0x9C, 0x0D, 0xE0, 0xFD, 0xFF, 0xFF, // mov     byte ptr [ebp+ecx+var_220], bl
+                                0x41 // inc ecx
+                            };
+                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                            if (l.Count == 0)
+                            {
+                                return false;
+                            }
+                            _posCalcLineBreakStart5 = l[0];
+                            pattern = new byte[]
+                            {
+                                0x88, 0x94, 0x0D, 0x34, 0xFB, 0xFF, 0xFF , // mov     byte ptr [ebp+ecx+var_4CC], dl
+                                0x41 // inc ecx
+                            };
+                            l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                            if (l.Count == 0)
+                            {
+                                return false;
+                            }
+                            _posCalcLineBreakStart6 = l[0];
+                            break;
                     }
-                    _posCalcLineBreakStart5 = l[0];
-
-                    pattern = new byte[]
-                    {
-                        0x88, 0x9C, 0x0D, 0xEC, 0xFD, 0xFF, 0xFF, 0x41
-                    };
-                    l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
-                    if (l.Count == 0)
-                    {
-                        return false;
-                    }
-                    _posCalcLineBreakStart6 = l[0];
                     break;
             }
 

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -2530,6 +2530,29 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
+                    pattern = new byte[]
+                    {
+                        0x2E, 0x20, 0x00, 0x00
+                    };
+                    l = BinaryScan(_data, pattern, _posRdataSection, _sizeRdataSection);
+                    if (l.Count == 0)
+                    {
+                        return false;
+                    }
+                    uint addrDivisionAbbrevA = GetRdataAddress(l[0]);
+                    pattern = new byte[]
+                    {
+                        0xBA, (byte) (addrDivisionAbbrevA & 0xFF), (byte) ((addrDivisionAbbrevA >> 8) & 0xFF),
+                        (byte) ((addrDivisionAbbrevA >> 16) & 0xFF), (byte) (addrDivisionAbbrevA >> 24)
+                    };
+                    l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                    if (l.Count == 0)
+                    {
+                        return false;
+                    }
+                    _posGetDivisionName1 = l[0] + 1;
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
@@ -2699,11 +2722,37 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
+                    pattern = new byte[]
+                    {
+                        0x8B, 0x4D, 0x08, // mov     ecx, [ebp+arg_0]
+                        0x51, // push ecx
+                        0xB9, 0x38, 0x53, 0xCE, 0x02 // mov     ecx, offset xxxxx
+                    };
+                    l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                    if (l.Count == 0)
+                    {
+                        return false;
+                    }
+                    _posGetArmyName1 = l[0] + 7;
+
+                    pattern = new byte[]
+                    {
+                        0x83, 0xC4, 0x08, 0x6A, 0x20
+                    };
+                    l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
+                    if (l.Count == 0)
+                    {
+                        return false;
+                    }
+                    _posGetArmyName2 = l[0] + 3;
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
-                        0xC7, 0x45, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, 0x8B,
-                        0x4D, 0x08, 0x51
+                        0xC7, 0x45, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, // mov     [ebp+var_4], 0FFFFFFFFh
+                        0x8B, 0x4D, 0x08,  // mov     ecx, [ebp+arg_0]
+                        0x51 // push    ecx
                     };
                     l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
                     if (l.Count == 0)
@@ -3289,11 +3338,19 @@ namespace EuropaEnginePatcher
             switch (_patchType)
             {
                 case PatchType.ArsenalOfDemocracy112:
+                    pattern = new byte[]
+                    {
+                        // 下側のコードが分岐するように変更になっている
+                        0xC6, 0x85, 0x48, 0xFF, 0xFF, 0xFF, 0x00, // mov     [ebp+var_B8], 0
+                        0x85, 0xC0 // test    eax, eax
+                    };
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     pattern = new byte[]
                     {
-                        0xC6, 0x85, 0x50, 0xFF, 0xFF, 0xFF, 0x00, 0x6A,
-                        0x00
+                        0xC6, 0x85, 0x50, 0xFF, 0xFF, 0xFF, 0x00, // mov     [ebp+var_B0], 0
+                        0x6A, 0x00 // push 0
                     };
                     break;
 

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -1960,8 +1960,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd2 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd2 = l[1] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -1974,8 +1974,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd6 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd6 = l[1] + (uint)pattern.Length;
                     break;
 
                 case PatchType.EuropaUniversalis2:
@@ -1989,8 +1989,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd2 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd2 = l[1] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2002,7 +2002,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2014,7 +2014,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd4 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd4 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2026,8 +2026,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd6 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd6 = l[1] + (uint)pattern.Length;
                     break;
 
                 case PatchType.ForTheGlory:
@@ -2041,7 +2041,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2053,7 +2053,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd2 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd2 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2065,7 +2065,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2077,8 +2077,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd6 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd6 = l[1] + (uint)pattern.Length;
                     break;
 
                 case PatchType.Victoria:
@@ -2092,8 +2092,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd2 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd2 = l[1] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2106,7 +2106,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2119,8 +2119,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd6 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd6 = l[1] + (uint)pattern.Length;
                     break;
 
                 case PatchType.HeartsOfIron:
@@ -2134,8 +2134,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd2 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd2 = l[1] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2148,7 +2148,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2161,8 +2161,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd6 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd6 = l[1] + (uint)pattern.Length;
                     break;
 
                 case PatchType.HeartsOfIron2:
@@ -2181,8 +2181,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd2 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd2 = l[1] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2194,7 +2194,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2206,7 +2206,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2218,7 +2218,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd6 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd6 = l[0] + (uint)pattern.Length;
                     break;
 
                 case PatchType.DarkestHour105:
@@ -2285,8 +2285,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd2 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd2 = l[1] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2299,7 +2299,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2311,8 +2311,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd6 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd6 = l[1] + (uint)pattern.Length;
                     break;
 
                 case PatchType.ArsenalOfDemocracy109:
@@ -2327,8 +2327,8 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
-                    _posCalcLineBreakEnd2 = l[1] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
+                    _posCalcLineBreakEnd2 = l[1] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2340,7 +2340,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2353,7 +2353,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2366,7 +2366,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd6 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd6 = l[0] + (uint)pattern.Length;
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
@@ -2381,7 +2381,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd1 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd1 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2393,7 +2393,7 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd2 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd2 = l[0] + (uint)pattern.Length;
 
                     pattern = new byte[]
                     {
@@ -2405,25 +2405,49 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd3 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd3 = l[0] + (uint)pattern.Length;
 
-                    pattern = new byte[]
-                    {
-                        0x8D, 0x85, 0xE8, 0xF9, 0xFF, 0xFF, 0x66, 0xC7,
-                        0x84, 0x0D, 0xE8, 0xFD, 0xFF, 0xFF, 0x20, 0x00
-                    };
+                    // _posCalcLineBreakEnd5
+                    switch (_patchType) {
+                        case PatchType.ArsenalOfDemocracy110:
+                            pattern = new byte[]
+                            {
+                                0x8D, 0x85, 0xE8, 0xF9, 0xFF, 0xFF, // lea     eax, [ebp+var_618]
+                                0x66, 0xC7, 0x84, 0x0D, 0xE8, 0xFD, 0xFF, 0xFF, 0x20, 0x00 // mov     [ebp+ecx+var_218], 20h
+                            };
+                            break;
+                        case PatchType.ArsenalOfDemocracy112:
+                            pattern = new byte[]
+                            {
+                                0x8D, 0x85, 0xE0, 0xF9, 0xFF, 0xFF, // lea     eax, [ebp+var_620]
+                                0x66, 0xC7, 0x84, 0x0D, 0xE0, 0xFD, 0xFF, 0xFF, 0x20, 0x00 // mov     [ebp+ecx+var_220], 20h
+                            };
+                            break;
+                    }
                     l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
                     if (l.Count == 0)
                     {
                         return false;
                     }
-                    _posCalcLineBreakEnd5 = l[0] + (uint) pattern.Length;
+                    _posCalcLineBreakEnd5 = l[0] + (uint)pattern.Length;
 
-                    pattern = new byte[]
-                    {
-                        0x8D, 0x85, 0xEC, 0xFB, 0xFF, 0xFF, 0x66, 0xC7,
-                        0x84, 0x0D, 0xEC, 0xFD, 0xFF, 0xFF, 0x20, 0x00
-                    };
+                    // _posCalcLineBreakEnd6
+                    switch (_patchType) {
+                        case PatchType.ArsenalOfDemocracy110:
+                            pattern = new byte[]
+                            {
+                                0x8D, 0x85, 0xEC, 0xFB, 0xFF, 0xFF, // lea     eax, [ebp+var_414]
+                                0x66, 0xC7, 0x84, 0x0D, 0xEC, 0xFD, 0xFF, 0xFF, 0x20, 0x00 // mov     [ebp+ecx+var_214], 20h
+                            };
+                            break;
+                        case PatchType.ArsenalOfDemocracy112:
+                            pattern = new byte[]
+                            {
+                                0x8D, 0x85, 0x34, 0xFD, 0xFF, 0xFF, // lea     eax, [ebp+var_2CC]
+                                0x66, 0xC7, 0x84, 0x0D, 0x34, 0xFB, 0xFF, 0xFF, 0x20, 0x00 // mov     [ebp+ecx+var_4CC], 20h
+                            };
+                            break;
+                    }
                     l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
                     if (l.Count == 0)
                     {

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -2733,18 +2733,18 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posGetArmyName1 = l[0] + 7;
+                    _posGetArmyName1 = l[0];
 
                     pattern = new byte[]
                     {
-                        0x83, 0xC4, 0x08, 0x6A, 0x20
+                        0xE8, 0xBE, 0xA6, 0xED, 0xFF // call    sub_4327B0
                     };
                     l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
                     if (l.Count == 0)
                     {
                         return false;
                     }
-                    _posGetArmyName2 = l[0] + 3;
+                    _posGetArmyName2 = l[0] + 5; // mov     dl, 20h
                     break;
 
                 case PatchType.ArsenalOfDemocracy110:
@@ -2759,18 +2759,19 @@ namespace EuropaEnginePatcher
                     {
                         return false;
                     }
-                    _posGetArmyName1 = l[0] + 7;
+                    _posGetArmyName1 = l[0] + 7; // mov     ecx, [ebp+arg_0]
 
                     pattern = new byte[]
                     {
-                        0x83, 0xC4, 0x08, 0x6A, 0x20
+                        0x83, 0xC4, 0x08, // add esp, 8
+                        0x6A, 0x20 // push 20h
                     };
                     l = BinaryScan(_data, pattern, _posTextSection, _sizeTextSection);
                     if (l.Count == 0)
                     {
                         return false;
                     }
-                    _posGetArmyName2 = l[0] + 3;
+                    _posGetArmyName2 = l[0] + 3; // push 20h
                     break;
             }
 
@@ -7638,11 +7639,67 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
-                case PatchType.ArsenalOfDemocracy110:
-                    uint addrBufOrdinal = GetLong(_posGetArmyName1 + 5);
-                    uint addrPutNumber = GetLong(_posGetArmyName1 + 11);
+                    uint addrBufOrdinal1 = GetLong(_posGetArmyName1 + 5); // offset xxxxx
+                    uint addrPutNumber1 = GetLong(_posGetArmyName1 + 11); // std::basic_ostream<char,std::char_traits<char>>::operator<<(uint)
                     offset = _posGetArmyName1;
-                    PatchByte(_data, offset, 0xEB); // jmp GET_ORDINAL_SUFFIX
+                    PatchByte(_data, offset, 0xEB); // jmp GET_ORDINAL_SUFFIX // goto mov     eax, [ebp+arg_0]
+                    offset++;
+                    PatchByte(_data, offset, 0x0D); // 変更なし
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+                    offset++;
+                    PatchByte(_data, offset, 0x90); // nop
+
+                    offset = _posGetArmyName2;
+                    PatchByte(_data, offset, 0x8B); // mov ecx,[ebp+08h] // arg_0
+                    offset++;
+                    PatchByte(_data, offset, 0x4D);
+                    offset++;
+                    PatchByte(_data, offset, 0x08);
+                    offset++;
+                    PatchByte(_data, offset, 0x51); // push ecx
+                    offset++;
+                    PatchByte(_data, offset, 0xB9); // mov ecx,addrBufOrdinal
+                    offset++;
+                    PatchLong(_data, offset, addrBufOrdinal1, $"%XX ${addrBufOrdinal1:X8} addrBufOrdinal");
+                    offset += 4;
+                    PatchByte(_data, offset, 0xFF); // call PutNumber
+                    offset++;
+                    PatchByte(_data, offset, 0x15);
+                    offset++;
+                    PatchLong(_data, offset, addrPutNumber1, $"%XX ${addrPutNumber1:X8} addrPutNumber");
+
+                    // TODO : ここは領域が足りなくて上書きできない
+
+                    break;
+
+                case PatchType.ArsenalOfDemocracy110:
+                    uint addrBufOrdinal = GetLong(_posGetArmyName1 + 5); // offset xxxxx
+                    uint addrPutNumber = GetLong(_posGetArmyName1 + 11); // std::basic_ostream<char,std::char_traits<char>>::operator<<(uint)
+                    offset = _posGetArmyName1;
+                    PatchByte(_data, offset, 0xEB); // jmp GET_ORDINAL_SUFFIX // goto mov     eax, [ebp+arg_0]
                     offset++;
                     PatchByte(_data, offset, 0x0D);
                     offset++;
@@ -7673,7 +7730,7 @@ namespace EuropaEnginePatcher
                     PatchByte(_data, offset, 0x90); // nop
 
                     offset = _posGetArmyName2;
-                    PatchByte(_data, offset, 0x8B); // mov ecx,[ebp+08h]
+                    PatchByte(_data, offset, 0x8B); // mov ecx,[ebp+08h] // arg_0
                     offset++;
                     PatchByte(_data, offset, 0x4D);
                     offset++;
@@ -7690,6 +7747,9 @@ namespace EuropaEnginePatcher
                     PatchByte(_data, offset, 0x15);
                     offset++;
                     PatchLong(_data, offset, addrPutNumber, $"%XX ${addrPutNumber:X8} addrPutNumber");
+
+                    // mov     ecx, [ebp+var_C]
+
                     break;
             }
 

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -6249,7 +6249,7 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
-                    // TODO: TBD
+                    // TODO: asm code to binary
                     // mov ecx, dword ptr [ebp - 14h];
                     // dec ecx;
                     // mov dword ptr [ebp - 14h], ecx;
@@ -6587,7 +6587,7 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
-                    // TODO:
+                    // TODO: asm code to binary
                     // mov ecx, [ebp - 14h];
                     // add ecx, eax;
                     // mov [ebp - 14h], ecx;
@@ -6797,6 +6797,15 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
+                    // TODO: asm code to binary
+                    // mov ecx, dword ptr [ebp - 18h];
+                    // dec ecx;
+                    // mov dword ptr [ebp - 18h], ecx;
+                    // push ecx
+                    // lea eax, [ebp - 4CCh];
+                    // push ecx
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x8D); // lea esi,[esi-01h]
                     offset++;
@@ -7138,6 +7147,13 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
+                    // TODO: asm code to binary
+                    // mov ecx, [ebp - 18h];
+                    // add ecx, eax;
+                    // mov [ebp - 18h], ecx;
+                    // lea eax, [ebp-2CCh];
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x01); // add esi,eax
                     offset++;

--- a/EuropaEnginePatcher/PatchEngine.cs
+++ b/EuropaEnginePatcher/PatchEngine.cs
@@ -4382,7 +4382,7 @@ namespace EuropaEnginePatcher
                     PatchByte(_data, offset, 0x17);
                     break;
 
-                case PatchType.ArsenalOfDemocracy112:
+                case PatchType.ArsenalOfDemocracy112: // pop edi
                 case PatchType.ArsenalOfDemocracy110:
                 case PatchType.ArsenalOfDemocracy109:
                     PatchByte(_data, offset, 0x16);
@@ -6249,6 +6249,15 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
+                    // TODO: TBD
+                    // mov ecx, dword ptr [ebp - 14h];
+                    // dec ecx;
+                    // mov dword ptr [ebp - 14h], ecx;
+                    // push ecx
+                    // lea eax, [ebp - 220h];
+                    // push ecx
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x8D); // lea esi,[esi-01h]
                     offset++;
@@ -6578,6 +6587,13 @@ namespace EuropaEnginePatcher
                     break;
 
                 case PatchType.ArsenalOfDemocracy112:
+                    // TODO:
+                    // mov ecx, [ebp - 14h];
+                    // add ecx, eax;
+                    // mov [ebp - 14h], ecx;
+                    // lea eax, [ebp-620h];
+                    break;
+
                 case PatchType.ArsenalOfDemocracy110:
                     PatchByte(_data, offset, 0x01); // add esi,eax
                     offset++;


### PR DESCRIPTION
- version: 0.55 -> 0.56
- タグ追加
  - ArsenalOfDemocracy110
  - ArsenalOfDemocracy111
  - ArsenalOfDemocracy112
  - ArsenalOfDemocracyVersionUnknown
- 検出パターン変更
  - _posLatinToUpper
  - _posCalcLineBreakEnd5
  - _posCalcLineBreakStart5
  - _posCalcLineBreakEnd6
  - _posCalcLineBreakStart6
  - _posGetArmyName1
  - _posGetArmyName2
  - _posGetDivisionName1
  - _posTermModelNameStart1
  - _posTermModelNameStart2
- 処理修正
  - _posLatinToUpper
     - 変更なし
  - _posCalcLineBreakEnd5 - _posCalcLineBreakStart5
     - TBD
  - _posCalcLineBreakEnd6 - _posCalcLineBreakStart6
     - TBD
  - _posGetArmyName1 - _posGetArmyName2
     - 領域が足りなくてどうしようもない。元のコードがバイパスしてない